### PR TITLE
Use pkg-config to determin libs and cflags

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -6,9 +6,9 @@ RM ?= rm
 
 CFLAGS ?= -O2
 
-override CFLAGS += -std=gnu99  -Wall -fpic -I. $(shell erl -noinput -eval 'io:format("-I~s/erts-~s/include", [code:root_dir(), erlang:system_info(version)]), halt(0).')
+override CFLAGS += -std=gnu99  -Wall -fpic -I. $(shell erl -noinput -eval 'io:format("-I~s/erts-~s/include", [code:root_dir(), erlang:system_info(version)]), halt(0).') $(shell pkg-config --cflags libsystemd)
 
-override LDFLAGS += -shared -fpic -lsystemd-journal -lsystemd-id128
+override LDFLAGS += -shared -fpic $(shell pkg-config --libs libsystemd)
 
 all : $(PRIVDIR)/journald_api.so
 


### PR DESCRIPTION
This makes us immune against systemd's library splits and joins (like
all libs being integrated into libsystemd)
