### PR TITLE
check if systemd symbols can resolve

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -5,13 +5,17 @@ CFLAGS ?= -O2
 
 override CFLAGS += -std=gnu99  -Wall -fpic -I. $(shell erl -noinput -eval 'io:format("-I~s/erts-~s/include", [code:root_dir(), erlang:system_info(version)]), halt(0).') $(shell pkg-config --cflags libsystemd-journal)
 
-override LDFLAGS += -shared -fpic $(shell pkg-config --libs libsystemd-journal)
+override LDFLAGS += -fpic
+LDLIBS = $(shell pkg-config --libs libsystemd-journal)
 
 all : $(PRIVDIR)/journald_api.so
 
+# check if systemd symbols can be resolved
+journald_api.o: check-journald
+
 $(PRIVDIR)/journald_api.so : journald_api.o
 	mkdir -p $(PRIVDIR)
-	$(CC) $^ $(LDFLAGS) -o $@
+	$(CC) $^ -shared $(LDFLAGS) $(LDLIBS) -o $@
 
 clean:
-	$(RM) -f $(PRIVDIR)/journald_api.so journald_api.o
+	$(RM) -f $(PRIVDIR)/journald_api.so journald_api.o check-journald

--- a/c_src/check-journald.c
+++ b/c_src/check-journald.c
@@ -1,0 +1,28 @@
+/* 
+ Copyright 2015, Travelping GmbH <copyright@travelping.com>
+
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE.
+*/
+
+#include <systemd/sd-journal.h>
+
+int main(int argc, char **argv) {
+	sd_journal *journal_pointer=NULL;
+	return sd_journal_open_directory(&journal_pointer, "/var/empty", 0);
+}

--- a/c_src/check-journald.c
+++ b/c_src/check-journald.c
@@ -1,23 +1,7 @@
 /* 
  Copyright 2015, Travelping GmbH <copyright@travelping.com>
 
- Permission is hereby granted, free of charge, to any person obtaining a
- copy of this software and associated documentation files (the "Software"),
- to deal in the Software without restriction, including without limitation
- the rights to use, copy, modify, merge, publish, distribute, sublicense,
- and/or sell copies of the Software, and to permit persons to whom the
- Software is furnished to do so, subject to the following conditions:
-
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
-
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- DEALINGS IN THE SOFTWARE.
+ This is nothing more than a compile- and link-check.
 */
 
 #include <systemd/sd-journal.h>

--- a/rebar.config
+++ b/rebar.config
@@ -9,4 +9,7 @@
              "$LDFLAGS $(pkg-config --libs libsystemd-journal)"}
            ]
 }.
-{port_specs, [{"priv/journald_api.so", ["c_src/*.c"]}]}.
+{port_specs, [
+              {"check-journald", ["c_src/check-journald.c"]},
+              {"priv/journald_api.so", ["c_src/*.c"]}
+             ]}.


### PR DESCRIPTION
Currently pkg-config is used to get CFLAGS and LDFLAGS for
compiling/linking against systemd headers/libs.
A failing pkg-config call (e.g. missing or renamed .pc file)
would not add any build flags and not break the build.
This can result in successfully building a disfunctional
NIF because gcc/ld (naturally) does not fail on unresolved
symbols when building a shared library. The missing linkage
would only surface at runtime. This patch makes sure rebar
and tetrapak builds fail when pkg-config does not provide
necessary link options.