### PR TITLE
Updated rebar.config for Erlang/OTP 18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %%-*- mode: erlang -*-
 
-{require_otp_vsn, "R16|17"}.
+{require_otp_vsn, "R16|17|18"}.
 {erl_opts, [debug_info, warn_unused_vars, warn_shadow_vars, warn_unused_import]}.
 {port_env, [
             {"linux", "CFLAGS",


### PR DESCRIPTION
I've tested ejournald on Erlang/OTP 18 and it works just fine.