### PR TITLE
Added support for OTP R19

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %%-*- mode: erlang -*-
 
-{require_otp_vsn, "R16|17|18"}.
+{require_otp_vsn, "R16|17|18|19"}.
 {erl_opts, [debug_info, warn_unused_vars, warn_shadow_vars, warn_unused_import]}.
 {port_env, [
             {"linux", "CFLAGS",


### PR DESCRIPTION
Checked on OTP R19 on Ubuntu 16.04 and works as expected.